### PR TITLE
Add mock tournaments data service with Faker.js

### DIFF
--- a/entities/index.ts
+++ b/entities/index.ts
@@ -16,9 +16,15 @@ export interface Team {
 
 export interface GameStat {
     id: number;
-    goal: number;
+    type: GameStatType;
     player: Player;
     time: Date;
+}
+
+export enum GameStatType {
+    goal = 'goal',
+    yellowCard = 'yellow card',
+    redCard = 'red card'
 }
 
 export interface Game {

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
       },
       "devDependencies": {
         "@babel/core": "^7.20.0",
+        "@faker-js/faker": "^8.4.1",
         "@types/jest": "^29.5.12",
         "@types/react": "~18.2.45",
         "@types/react-test-renderer": "^18.0.7",
@@ -3280,6 +3281,22 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-8.4.1.tgz",
+      "integrity": "sha512-XQ3cU+Q8Uqmrbf2e0cIC/QN43sTBSC8KF12u29Mb47tWrt2hAgBXSgpZMj4Ao8Uk0iJcU99QsOCaIL8934obCg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
+        "npm": ">=6.14.13"
       }
     },
     "node_modules/@graphql-typed-document-node/core": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",
+    "@faker-js/faker": "^8.4.1",
     "@types/jest": "^29.5.12",
     "@types/react": "~18.2.45",
     "@types/react-test-renderer": "^18.0.7",

--- a/services/tournaments.service.ts
+++ b/services/tournaments.service.ts
@@ -1,5 +1,5 @@
 import {faker} from '@faker-js/faker';
-import {Game, GameStat, League, Player, Team} from "@/entities";
+import {Game, GameStat, GameStatType, League, Player, Team} from "@/entities";
 
 const generateMockPlayers = (count: number): Player[] => {
     return Array.from({length: count}, (_, id) => ({
@@ -21,20 +21,22 @@ const generateMockTeams = (count: number, playersPerTeam: number): Team[] => {
 const generateMockGameStats = (players: Player[], count: number): GameStat[] => {
     return Array.from({length: count}, (_, id) => ({
         id: id + 1,
-        goal: faker.number.int({min: 0, max: 5}),
+        goal: faker.helpers.enumValue(GameStatType),
         player: players[faker.number.int({min: 0, max: players.length - 1})],
         time: faker.date.past()
     }));
 };
 
 const generateMockGames = (teams: Team[], count: number): Game[] => {
+    const homeTeam = teams[faker.number.int({min: 0, max: teams.length - 1})];
+    const awayTeam = teams[faker.number.int({min: 0, max: teams.length - 1})];
     return Array.from({length: count}, (_, id) => ({
         id: id + 1,
-        homeTeam: teams[faker.number.int({min: 0, max: teams.length - 1})],
-        awayTeam: teams[faker.number.int({min: 0, max: teams.length - 1})],
+        homeTeam: homeTeam,
+        awayTeam: awayTeam,
         address: faker.location.streetAddress(),
         date: faker.date.future(),
-        stats: generateMockGameStats(teams.flatMap(team => team.players), 5)
+        stats: generateMockGameStats(homeTeam.players.concat(awayTeam.players), 5)
     }));
 };
 

--- a/services/tournaments.service.ts
+++ b/services/tournaments.service.ts
@@ -1,0 +1,70 @@
+import {faker} from '@faker-js/faker';
+import {Game, GameStat, League, Player, Team} from "@/entities";
+
+const generateMockPlayers = (count: number): Player[] => {
+    return Array.from({length: count}, (_, id) => ({
+        id: id + 1,
+        name: faker.person.fullName(),
+        email: faker.internet.email(),
+        position: faker.number.int({min: 1, max: 11})
+    }));
+};
+
+const generateMockTeams = (count: number, playersPerTeam: number): Team[] => {
+    return Array.from({length: count}, (_, id) => ({
+        id: id + 1,
+        name: faker.company.name(),
+        players: generateMockPlayers(playersPerTeam)
+    }));
+};
+
+const generateMockGameStats = (players: Player[], count: number): GameStat[] => {
+    return Array.from({length: count}, (_, id) => ({
+        id: id + 1,
+        goal: faker.number.int({min: 0, max: 5}),
+        player: players[faker.number.int({min: 0, max: players.length - 1})],
+        time: faker.date.past()
+    }));
+};
+
+const generateMockGames = (teams: Team[], count: number): Game[] => {
+    return Array.from({length: count}, (_, id) => ({
+        id: id + 1,
+        homeTeam: teams[faker.number.int({min: 0, max: teams.length - 1})],
+        awayTeam: teams[faker.number.int({min: 0, max: teams.length - 1})],
+        address: faker.location.streetAddress(),
+        date: faker.date.future(),
+        stats: generateMockGameStats(teams.flatMap(team => team.players), 5)
+    }));
+};
+
+const generateMockLeagues = (count: number, teamsPerLeague: number, gamesPerLeague: number): League[] => {
+    return Array.from({length: count}, (_, id) => ({
+        id: id + 1,
+        name: faker.company.name(),
+        status: faker.number.int({min: 0, max: 3}), // 0 = open, 1 = closed, 2 = ongoing, 3 = ended, these are just some ideas
+        teams: generateMockTeams(teamsPerLeague, 15),
+        games: generateMockGames(generateMockTeams(teamsPerLeague, 15), gamesPerLeague)
+    }));
+};
+
+const mockPlayers = generateMockPlayers(50);
+const mockTeams = generateMockTeams(10, 15);
+const mockGames = generateMockGames(mockTeams, 20);
+const mockLeagues = generateMockLeagues(5, 10, 20);
+
+export const getPlayers = async (): Promise<Player[]> => {
+    return mockPlayers;
+};
+
+export const getTeams = async (): Promise<Team[]> => {
+    return mockTeams;
+};
+
+export const getGames = async (): Promise<Game[]> => {
+    return mockGames;
+};
+
+export const getLeagues = async (): Promise<League[]> => {
+    return mockLeagues;
+};


### PR DESCRIPTION
This commit sets up a mock data service using Faker.js, including players, teams, games, and leagues.




