### PR TITLE
Show score on game cards for past and current games

### DIFF
--- a/openspec/changes/archive/2026-05-13-show-scores-for-past-and-current-games/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-13-show-scores-for-past-and-current-games/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-13

--- a/openspec/changes/archive/2026-05-13-show-scores-for-past-and-current-games/design.md
+++ b/openspec/changes/archive/2026-05-13-show-scores-for-past-and-current-games/design.md
@@ -1,0 +1,57 @@
+## Context
+
+`GameExcerpt` (`store/leagues/GameExcerpt.tsx`) renders one card per game in the league schedule. It currently shows the home team avatar/name, a static `"vs"` label, the away team avatar/name, and the formatted game date. It receives a `GameResponse` which includes `gameDateTime: string`, `durationInMinutes: number`, and `stats: GameStatResponse[]`. Goal counts are not stored directly — they are derived by counting `GameStatResponse` entries of type `GameStatType.goal` per team.
+
+The game detail screen (`[gameId].tsx`) already derives scores this way: it filters `game.stats` by type and team, then uses `.length` as the goal count. The same pattern applies here.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Classify each game as `upcoming`, `live`, or `past` at render time using wall-clock comparison against `gameDateTime` and `durationInMinutes`.
+- Show the score (`homeGoals – awayGoals`) in the center of the card for `live` and `past` games.
+- Show a `LIVE` badge for in-progress games.
+- Show `"vs"` in the center for `upcoming` games (no change from today).
+
+**Non-Goals:**
+- Real-time polling or live score updates — the score reflects whatever stats are in the Redux store at render time.
+- Sorting or grouping games by status in the schedule list.
+- Changing any card layout outside the center section.
+- Server-side game state — classification is purely client-side.
+
+## Decisions
+
+### Single utility function `getGameStatus`
+Encapsulate the classification logic in `utils/gameStatus.ts` rather than inlining it in `GameExcerpt`. This keeps the component readable and makes the logic independently testable.
+
+```ts
+type GameStatus = 'upcoming' | 'live' | 'past';
+
+function getGameStatus(gameDateTime: string, durationInMinutes: number): GameStatus {
+  const start = new Date(gameDateTime).getTime();
+  const end = start + durationInMinutes * 60_000;
+  const now = Date.now();
+  if (now < start) return 'upcoming';
+  if (now < end)   return 'live';
+  return 'past';
+}
+```
+
+*Alternative considered*: Inline in `GameExcerpt`. Rejected — harder to test and clutters the component.
+
+### Score derived from `game.stats` in the component
+Filter `game.stats` for `GameStatType.goal` entries matching `homeTeamId` / `awayTeamId` and use `.length`. This mirrors the existing pattern in `[gameId].tsx` and requires no store changes.
+
+*Alternative considered*: Add a `score` selector to the games slice. Rejected — over-engineering for display-only data already available on the `GameResponse`.
+
+### Replace `"vs"` with score in the center column
+For non-upcoming games, render `homeGoals – awayGoals` where `"vs"` currently sits. This keeps the card layout stable (same three columns) while naturally conveying the result. The `LIVE` badge sits below the score on live games.
+
+*Alternative considered*: Add a separate score row below the matchup row. Rejected — uses more vertical space and makes the card taller only for some games.
+
+### No style changes to team-side columns
+The team name and avatar layout is unchanged. Only the center section changes.
+
+## Risks / Trade-offs
+
+- **Stats not yet loaded**: If `game.stats` is empty for a past game (e.g., no stats were entered), the score shows `0 – 0`. This is acceptable — it accurately reflects what's in the store.
+- **Clock skew / timezone**: Classification uses `Date.now()` vs `new Date(gameDateTime)`. The server stores `gameDateTime` as an ISO string; JavaScript's `Date` handles this correctly as long as the string includes a timezone offset. If the API returns naive timestamps, games near the boundary may be misclassified by a few hours. This is a pre-existing data concern, not introduced by this change.

--- a/openspec/changes/archive/2026-05-13-show-scores-for-past-and-current-games/proposal.md
+++ b/openspec/changes/archive/2026-05-13-show-scores-for-past-and-current-games/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+The league schedule currently shows all games in identical cards — a matchup and a date — with no indication of whether a game has already been played, is in progress, or is yet to come. Users cannot tell at a glance which games have results without tapping into each one. Surfacing the score directly on the card for finished and live games makes the schedule useful as a standings-at-a-glance, while keeping upcoming game cards clean and uncluttered.
+
+## What Changes
+
+- Add a `getGameStatus` utility that classifies a `GameResponse` as `'upcoming'`, `'live'`, or `'past'` using `gameDateTime` and `durationInMinutes`.
+- Update `GameExcerpt` to compute the home and away goal counts from `game.stats` and render a score row for `'live'` and `'past'` games; render nothing in that slot for `'upcoming'` games.
+- Add a `LIVE` badge on the score row for in-progress games to make the live state visually distinct.
+- Replace the static `"vs"` separator with a score display (`homeGoals – awayGoals`) for non-upcoming games, keeping `"vs"` only for upcoming ones.
+
+## Capabilities
+
+### New Capabilities
+
+- `game-score-on-card`: Past and live games display the current/final score (`homeGoals – awayGoals`) directly on the schedule card. Upcoming games show no score.
+- `live-game-indicator`: A `LIVE` badge appears on in-progress game cards.
+
+### Modified Capabilities
+
+- `game-excerpt-card`: The center section of the card now conditionally shows either a `"vs"` label (upcoming) or a score (live/past). No layout changes to the team-side columns.
+
+## Impact
+
+- **Utility added**: `utils/gameStatus.ts`
+- **Component changed**: `store/leagues/GameExcerpt.tsx`
+- **No API, store, or routing changes** — purely display logic

--- a/openspec/changes/archive/2026-05-13-show-scores-for-past-and-current-games/tasks.md
+++ b/openspec/changes/archive/2026-05-13-show-scores-for-past-and-current-games/tasks.md
@@ -1,0 +1,17 @@
+## 1. Add `getGameStatus` utility
+
+- [x] 1.1 Create `utils/gameStatus.ts` exporting:
+  - `type GameStatus = 'upcoming' | 'live' | 'past'`
+  - `function getGameStatus(gameDateTime: string, durationInMinutes: number): GameStatus` — returns `'upcoming'` if `now < start`, `'live'` if `start <= now < end`, `'past'` otherwise
+
+## 2. Update `GameExcerpt`
+
+- [x] 2.1 Import `getGameStatus` from `@/utils/gameStatus` and `GameStatType` from `@/entities/index`
+- [x] 2.2 Inside `GameExcerpt`, derive `status` by calling `getGameStatus(game.gameDateTime, game.durationInMinutes)`
+- [x] 2.3 Compute `homeGoals` and `awayGoals` by filtering `game.stats` for `type === GameStatType.goal` and matching `player`'s team — use `game.homeTeam.id` and `game.awayTeam.id` to attribute goals
+- [x] 2.4 Replace the static `<Text style={styles.vs}>vs</Text>` with a conditional:
+  - `upcoming` → render `<Text style={styles.vs}>vs</Text>` (unchanged)
+  - `live` or `past` → render a `<View>` containing `<Text style={styles.score}>{homeGoals} – {awayGoals}</Text>` and, for `live` only, a `<Text style={styles.liveBadge}>LIVE</Text>` below it
+- [x] 2.5 Add `score` and `liveBadge` entries to `StyleSheet.create`:
+  - `score`: `{ fontSize: 20, fontWeight: 'bold', color: '#111', textAlign: 'center' }`
+  - `liveBadge`: `{ fontSize: 11, fontWeight: '700', color: '#fff', backgroundColor: '#e53e3e', borderRadius: 4, paddingHorizontal: 6, paddingVertical: 2, overflow: 'hidden', marginTop: 4, alignSelf: 'center' }`

--- a/store/leagues/GameExcerpt.tsx
+++ b/store/leagues/GameExcerpt.tsx
@@ -8,7 +8,12 @@ import {
 } from 'react-native';
 import { Avatar } from '@/components/Avatar';
 import { Link } from 'expo-router';
-import { GameResponse } from '@/entities/index';
+import { 
+    GameResponse, 
+    GameStatType, 
+    countStatsForTeam 
+} from '@/entities/index';
+import { getGameStatus } from '@/utils/gameStatus';
 import { format } from 'date-fns';
 import { es, enUS } from 'date-fns/locale';
 import { useLocalSearchParams } from 'expo-router';
@@ -57,6 +62,28 @@ const styles = StyleSheet.create({
         color: '#888',
         marginHorizontal: 8,
     },
+    scoreCenter: {
+        alignItems: 'center',
+        marginHorizontal: 8,
+    },
+    score: {
+        fontSize: 20,
+        fontWeight: 'bold',
+        color: '#111',
+        textAlign: 'center',
+    },
+    liveBadge: {
+        fontSize: 11,
+        fontWeight: '700',
+        color: '#fff',
+        backgroundColor: '#e53e3e',
+        borderRadius: 4,
+        paddingHorizontal: 6,
+        paddingVertical: 2,
+        overflow: 'hidden',
+        marginTop: 4,
+        alignSelf: 'center',
+    },
     dateRow: {
         marginTop: 12,
         alignItems: 'center',
@@ -74,6 +101,10 @@ export function GameExcerpt({ game }: GameExcerptProps) {
     const formattedDate = formatDate(date);
     const { id } = useLocalSearchParams();
     const leagueId = Number(id);
+
+    const status = getGameStatus(game.gameDateTime, game.durationInMinutes);
+    const homeGoals = countStatsForTeam(game.stats, GameStatType.goal, game.homeTeam);
+    const awayGoals = countStatsForTeam(game.stats, GameStatType.goal, game.awayTeam);
 
     function formatDate(date: number): string {
         const dateString = format(date, 'eee, MMM d pp', { locale });
@@ -103,7 +134,16 @@ export function GameExcerpt({ game }: GameExcerptProps) {
                             <Text style={styles.teamName}>{game.homeTeam.name}</Text>
                         </View>
 
-                        <Text style={styles.vs}>vs</Text>
+                        {status === 'upcoming' ? (
+                            <Text style={styles.vs}>vs</Text>
+                        ) : (
+                            <View style={styles.scoreCenter}>
+                                <Text style={styles.score}>{homeGoals} – {awayGoals}</Text>
+                                {status === 'live' && (
+                                    <Text style={styles.liveBadge}>LIVE</Text>
+                                )}
+                            </View>
+                        )}
 
                         <View style={styles.teamSide}>
                             <Avatar

--- a/utils/gameStatus.ts
+++ b/utils/gameStatus.ts
@@ -1,0 +1,10 @@
+export type GameStatus = 'upcoming' | 'live' | 'past';
+
+export function getGameStatus(gameDateTime: string, durationInMinutes: number): GameStatus {
+  const start = new Date(gameDateTime).getTime();
+  const end = start + durationInMinutes * 60_000;
+  const now = Date.now();
+  if (now < start) return 'upcoming';
+  if (now < end) return 'live';
+  return 'past';
+}


### PR DESCRIPTION
Past and live games now display a goal score in the center of the schedule card instead of "vs". Live games also show a LIVE badge. Upcoming games are unchanged. Classification uses gameDateTime and durationInMinutes via a new getGameStatus utility.